### PR TITLE
Add speakerdeck link for jwt talk

### DIFF
--- a/August - 2017/README.md
+++ b/August - 2017/README.md
@@ -9,7 +9,7 @@
 
 ----
 * JSON Web Tokens - [Thameera Senanayaka](https://twitter.com/thameera)
-	* Slides : [PDF](https://github.com/CMBJS/Meetups/raw/master/August%20-%202017/jwt.pdf)
+	* Slides : [SpeakerDeck](https://speakerdeck.com/thameera/json-web-tokens) (or [PDF](https://github.com/CMBJS/Meetups/raw/master/August%20-%202017/jwt.pdf))
 
 ----
 


### PR DESCRIPTION
Pls ignore the other diff, it comes up no matter what and doesn't change anything.